### PR TITLE
Unset t:cwd on active tab page

### DIFF
--- a/plugin/tabpagecd.vim
+++ b/plugin/tabpagecd.vim
@@ -35,6 +35,7 @@ augroup plugin-tabpagecd
   autocmd TabEnter *
   \   if exists('t:cwd')
   \ |   cd `=t:cwd`
+  \ |   unlet t:cwd
   \ | endif
 
   autocmd TabLeave *


### PR DESCRIPTION
This stops `t:cwd` shadowing the current working directory while possibly getting out of sync with it.

Usage case example: setting `guitablabel` to display the tail of the current working directory – this needs `t:cwd` to be set for inactive tabs to display a correct value, but the active tab gets out of sync when we `cd` around and `t:cwd` is not updated to reflect that. Admittedly a corner case, but it can be resolved without any side effects by this PR AFAIK.
